### PR TITLE
hack: bind 5432 for internal haproxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       - internal
     ports:
       - "${PRIVATE_IP}:${PRIVATE_PORT}:80"
+      - "${PRIVATE_IP}:5432:5432"
     ulimits:
       nofile: 10240
     volumes:

--- a/init/template/haproxy-internal/haproxy.cfg.template
+++ b/init/template/haproxy-internal/haproxy.cfg.template
@@ -30,6 +30,12 @@ defaults
     # allows proxy to start immediately when some/all backends are not available
     default-server init-addr none
 
+listen postgres
+    bind *:5432
+    mode tcp
+    balance leastconn
+    server postgres postgres:5432 resolvers docker_resolver
+
 #---------------------------------------------------------------------
 # main frontend which proxys to the backends
 #---------------------------------------------------------------------


### PR DESCRIPTION
bit of a hack, as it assumes that everyone using this is running a postgres instance, and wishes to make it available over vpn using the internal proxy

a better solution would probably be to split out these applications to be "normal" applications as part of the template, allowing users to customize more easily, or start templating using helm or something.