### PR TITLE
fix: revert to running telegraf as root

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,12 @@ services:
     depends_on:
       - influxdb
       - haproxy_public
+    # hack: they changed their image to use a non-root user, but it makes managing permissions on the haproxy socket / docker socket a pain
+    #       https://www.influxdata.com/blog/docker-run-telegraf-as-non-root/
+    #       theoretically it'll respect group_add but it seems broken - I don't observe the groups being added to the telegraf user when exec
+    #       into the container. give up for now and force it to run as root.
+    user: 0:0
+    entrypoint: telegraf
     environment:
       HOST_PROC: /rootfs/proc
       HOST_SYS: /rootfs/sys
@@ -106,6 +112,14 @@ services:
       - type: bind
         source: /etc
         target: /rootfs/etc
+        read_only: true
+      - type: bind
+        source: /dev/xvda
+        target: /dev/xvda
+        read_only: true
+      - type: bind
+        source: /dev/xvda1
+        target: /dev/xvda1
         read_only: true
       - type: bind
         source: /run/utmp


### PR DESCRIPTION
it's not ideal, but despite https://github.com/influxdata/influxdata-docker/blame/master/telegraf/1.32/entrypoint.sh#L17-L28 I can't seem to make `group_add` work to otherwise solve the permissions issues I'm experiencing (docker socket, haproxy stats socket, etc).

running as root inside the container is how things worked until #6 earlier :shrug: - might have another go later when my patience has recovered.